### PR TITLE
Capitalization and typo fixes to the website

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
 <title>Minecraft seed converter</title>
 <p align="center"><font size="7"><font face="URW Gothic"><strong>Minecraft seed converter</strong></font></font></p>
-<p align="center"><font size="5"><font face="URW Gothic"><strong>Enter your minecraft world generation seed, and convert it to java or bedrock!</strong></font></font></p>
+<p align="center"><font size="5"><font face="URW Gothic"><strong>Enter your Minecraft world generation seed, and convert it to Java or Bedrock!</strong></font></font></p>
 
 <p align="center"><font size="3">The license is available <a href="https://github.com/Malwprotector/mc-seed-converter/blob/main/LICENSE.md">here.</a></font></p>
 <p align="center"><font size="3">You can get the source code <a href="https://github.com/Malwprotector/mc-seed-converter">here.</a> <br>Click the button below to download <br> offline version.</font></p>
@@ -10,11 +10,11 @@
 
 <p align="center"><font size="5"><font face="URW Gothic"><i>
 Please note that: <br>
- -All Bedrock sees can be converted to Java seeds. <br>
+ -All Bedrock seeds can be converted to Java seeds. <br>
   -You won’t be able to convert all Java seeds to Bedrock seeds. <br>
  -There will be some differences in the world that are generated. <br>
  -Spawn points will likely be different. <br>
- -Structures such as the Dessert temples, Jungle Temples, Mineshafts, Strongholds will not be in the same place. <br>
+ -Structures such as the Desert Temples, Jungle Temples, Mineshafts, Strongholds will not be in the same place. <br>
  -The Biomes and the map will be a close match to the original world seed. <br>
 </i></font></font></p>
 <p align="center"><font size="7"><font face="URW Gothic"><strong><a href="converter.html">convert!</a></strong></font></font></p>


### PR DESCRIPTION
Hello,

I checked the website for this repo, and I saw the same typos and capitalization errors that I previously fixed on my first pull request to this repo [here](github.com/Malwprotector/mc-seed-converter/pull/1). You can see what I edited in index.html anyway.

Typos:

Original: All Bedrock sees can be converted to Java seeds.
New: All Bedrock seeds can be converted to Java seeds.

Original: Structures such as the Dessert temples, Jungle Temples, Mineshafts, Strongholds will not be in the same place.
New: Structures such as the Desert Temples, Jungle Temples, Mineshafts, Strongholds will not be in the same place.

Capitalizations:
Changed "minecraft" to "Minecraft"
Changed "java" to "Java"
Changed "bedrock" to "Bedrock"

Best regards,
MKstar